### PR TITLE
chore: update datamodels and make adapters modular

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -4,6 +4,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+# TODO: Instead of llm, embedding service, use model name for choosing the service
+# if "gemini" in gemini-2.0-flash, gemini-embedding-001
 LLM_SERVICE = "gemini"
 DB_SERVICE = "chroma"
 # DB_SERVICE = "postgres"

--- a/src/memsrv/api/main.py
+++ b/src/memsrv/api/main.py
@@ -3,10 +3,9 @@ import os
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import logging
 
 from memsrv.api.routes import memory
-
+from memsrv.utils.logger import get_logger
 from memsrv.core.memory_service import MemoryService
 from memsrv.llms.providers.gemini import GeminiModel
 from memsrv.embeddings.providers.gemini import GeminiEmbedding
@@ -14,8 +13,7 @@ from memsrv.llms.base_config import BaseLLMConfig
 from config import LLM_SERVICE, DB_SERVICE, EMBEDDING_SERVICE, CONNECTION_STRING
 
 load_dotenv()
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def get_llm_instance():
     if LLM_SERVICE == "gemini":

--- a/src/memsrv/api/routes/memory.py
+++ b/src/memsrv/api/routes/memory.py
@@ -1,15 +1,13 @@
 """Actual end points will be defined here"""
-from fastapi import APIRouter, Query, HTTPException
 from typing import List, Dict, Optional, Any
-import logging
+from fastapi import APIRouter, Query, HTTPException
 
 from memsrv.core.memory_service import MemoryService
-
+from memsrv.utils.logger import get_logger
 from memsrv.models.request import MemoryCreateRequest, MemoryGenerateRequest, MemoryUpdateRequest
 from memsrv.models.response import MemoriesActionResponse, GetMemoriesResponse
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def create_memory_router(memory_service: MemoryService):
     router = APIRouter(tags=["Memory"])
@@ -99,20 +97,7 @@ def create_memory_router(memory_service: MemoryService):
             logger.exception(f"An error has occured when updating memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
     
-    @router.delete("/delete", response_model=MemoriesActionResponse)
-    def delete_memories(ids: List[str]):
-        """Deletes memories from database for given ids"""
-        try:
-            response = memory_service.delete_memories(memory_ids=ids)
-            return {
-                "message": f"Successfully deleted {len(response)} memories from database.",
-                "info": response
-            }
-        except Exception as e:
-            logger.exception(f"An error has occured when deleting memory: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail=str(e))
-    
-    @router.put("/update", response_model=MemoriesActionResponse)
+    @router.put("/memories/update", response_model=MemoriesActionResponse)
     def update_memories(items: List[MemoryUpdateRequest]):
         """Updates memories for given items"""
         try:
@@ -123,6 +108,19 @@ def create_memory_router(memory_service: MemoryService):
             }
         except Exception as e:
             logger.exception(f"An error has occured when updating memory: {str(e)}", exc_info=True)
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @router.delete("/memories/delete", response_model=MemoriesActionResponse)
+    def delete_memories(ids: List[str]):
+        """Deletes memories from database for given ids"""
+        try:
+            response = memory_service.delete_memories(memory_ids=ids)
+            return {
+                "message": f"Successfully deleted {len(response)} memories from database.",
+                "info": response
+            }
+        except Exception as e:
+            logger.exception(f"An error has occured when deleting memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
         
     return router

--- a/src/memsrv/api/routes/memory.py
+++ b/src/memsrv/api/routes/memory.py
@@ -4,7 +4,9 @@ from typing import List, Dict, Optional, Any
 import logging
 
 from memsrv.core.memory_service import MemoryService
-from memsrv.models.memory import MemoryMetadata, MemoryUpdateItem, GetMemoriesResponseModel, AddMemoriesResponseModel, DeleteMemoriesResponseModel, MemoryCreateItem
+
+from memsrv.models.request import MemoryCreateRequest, MemoryGenerateRequest, MemoryUpdateRequest
+from memsrv.models.response import MemoriesActionResponse, GetMemoriesResponse
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -12,12 +14,14 @@ logger = logging.getLogger(__name__)
 def create_memory_router(memory_service: MemoryService):
     router = APIRouter(tags=["Memory"])
 
-    @router.post("/memories/generate", response_model=AddMemoriesResponseModel)
-    def generate_memories(messages: List[dict], metadata: MemoryMetadata):
+    @router.post("/memories/generate", response_model=MemoriesActionResponse)
+    def generate_memories(request: MemoryGenerateRequest):
         """
         Extracts facts from a conversation and saves them with metadata.
         """
         try:
+            messages = request.messages
+            metadata = request.metadata
             response = memory_service.add_facts_from_conversation(messages, metadata)
             return {
                 "message": f"Successfully added {len(response)} memories to database.",
@@ -27,13 +31,13 @@ def create_memory_router(memory_service: MemoryService):
             logger.exception(f"An error has occured when adding to memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
 
-    @router.get("/memories", response_model=GetMemoriesResponseModel)
+    @router.get("/memories", response_model=GetMemoriesResponse)
     def retrieve_memories_by_metadata(
         user_id: Optional[str] = Query(None),
         session_id: Optional[str] = Query(None),
         app_id: Optional[str] = Query(None),
         limit: int = Query(50, ge=1, le=50)
-    ) -> GetMemoriesResponseModel:
+    ) -> GetMemoriesResponse:
         """Get memories by metadata filters only.
         e.g, /memories?user_id=u123&session_id=s123
         """
@@ -49,19 +53,19 @@ def create_memory_router(memory_service: MemoryService):
             # We can get the collection name from params as well, but for future
 
             memories = memory_service.search_memories_by_filter(filters=filters, limit=limit)
-            return GetMemoriesResponseModel(memories=memories)
+            return GetMemoriesResponse(memories=memories)
         except Exception as e:
             logger.exception(f"An error has occured when searching memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
 
-    @router.get("/memories/similar", response_model=GetMemoriesResponseModel)
+    @router.get("/memories/similar", response_model=GetMemoriesResponse)
     def retrieve_memories_by_similarity(
         query: str,
         user_id: Optional[str] = Query(None),
         session_id: Optional[str] = Query(None),
         app_id: Optional[str] = Query(None),
         limit: int = Query(50, ge=1, le=50)
-    ) -> GetMemoriesResponseModel:
+    ) -> GetMemoriesResponse:
         """Get memories by metadata filters and similarity match.
         e.g, /memories?query=What is my name?&user_id=u123&session_id=s123
         """
@@ -77,16 +81,16 @@ def create_memory_router(memory_service: MemoryService):
             memories = memory_service.search_memories_by_similarity(query=query,
                                                                     filters=filters,
                                                                     limit=limit)
-            return GetMemoriesResponseModel(memories=memories)
+            return GetMemoriesResponse(memories=memories)
         except Exception as e:
             logger.exception(f"An error has occured when searching memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
     
-    @router.post("/memories/create")
-    def create_memories(memories: MemoryCreateItem):
+    @router.post("/memories/create", response_model=MemoriesActionResponse)
+    def create_memories(request: MemoryCreateRequest):
         """Create a memory directly"""
         try:
-            response = memory_service.create_memories(data=memories)
+            response = memory_service.create_memories(data=request)
             return {
                 "message": f"Successfully created {len(response)} memories in the database.",
                 "info": response
@@ -95,7 +99,7 @@ def create_memory_router(memory_service: MemoryService):
             logger.exception(f"An error has occured when updating memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
     
-    @router.delete("/delete", response_model=DeleteMemoriesResponseModel)
+    @router.delete("/delete", response_model=MemoriesActionResponse)
     def delete_memories(ids: List[str]):
         """Deletes memories from database for given ids"""
         try:
@@ -108,8 +112,8 @@ def create_memory_router(memory_service: MemoryService):
             logger.exception(f"An error has occured when deleting memory: {str(e)}", exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
     
-    @router.put("/update")
-    def update_memories(items: List[MemoryUpdateItem]):
+    @router.put("/update", response_model=MemoriesActionResponse)
+    def update_memories(items: List[MemoryUpdateRequest]):
         """Updates memories for given items"""
         try:
             response = memory_service.update_memories(update_items=items)

--- a/src/memsrv/core/memory_service.py
+++ b/src/memsrv/core/memory_service.py
@@ -1,6 +1,4 @@
 """To add MemoryService class to add facts and to db services"""
-import os
-from dotenv import load_dotenv
 from typing import List, Dict, Optional, Any
 
 from memsrv.core.extractor import parse_messages, extract_facts
@@ -11,7 +9,6 @@ from memsrv.embeddings.base_embedder import BaseEmbedding
 from memsrv.models.memory import MemoryMetadata, MemoryInDB
 from memsrv.models.request import MemoryCreateRequest, MemoryUpdateRequest
 from memsrv.models.response import ActionConfirmation, MemoryResponse
-load_dotenv()
 
 class MemoryService:
     def __init__(self, llm: BaseLLM, db_adapter: VectorDBAdapter, embedder: BaseEmbedding):
@@ -77,7 +74,9 @@ class MemoryService:
                 MemoryResponse(
                     id=results["ids"][i],
                     document=results["documents"][i],
-                    metadata=results["metadatas"][i]
+                    metadata=results["metadatas"][i],
+                    created_at=results["metadatas"][i].get("created_at"),
+                    updated_at=results["metadatas"][i].get("updated_at")
                 )
             )
         
@@ -99,7 +98,9 @@ class MemoryService:
                     id=results["ids"][i],
                     document=results["documents"][i],
                     metadata=results["metadatas"][i],
-                    similarity=results["distances"][i]
+                    similarity=results["distances"][i],
+                    created_at=results["metadatas"][i].get("created_at"),
+                    updated_at=results["metadatas"][i].get("updated_at")
                 )
             )
         return memories
@@ -157,6 +158,7 @@ class MemoryService:
                 document=update_item.document,
                 embedding=new_embeddings[i],
                 metadata=update_item.metadata
+                # Get created at from existing record
             )
             for i, update_item in enumerate(update_items)
         ]

--- a/src/memsrv/core/memory_service.py
+++ b/src/memsrv/core/memory_service.py
@@ -7,8 +7,10 @@ from memsrv.core.extractor import parse_messages, extract_facts
 from memsrv.llms.base_llm import BaseLLM
 from memsrv.db.base_adapter import VectorDBAdapter
 from memsrv.embeddings.base_embedder import BaseEmbedding
-from memsrv.models.memory import MemoryItem, MemoryMetadata, DBMemoryItem, MemoryUpdateItem, MemoryResponseData, MemoryActionResponse, MemoryCreateItem
 
+from memsrv.models.memory import MemoryMetadata, MemoryInDB
+from memsrv.models.request import MemoryCreateRequest, MemoryUpdateRequest
+from memsrv.models.response import ActionConfirmation, MemoryResponse
 load_dotenv()
 
 class MemoryService:
@@ -24,10 +26,12 @@ class MemoryService:
         self.db = db_adapter
         self.embedder = embedder
     
-    def format_memory_response(self, fact_id: str, action: str,  fact_content: Optional[str]=None) -> MemoryActionResponse:
-        return MemoryActionResponse(
-            memory=MemoryResponseData(id=fact_id, content=fact_content),
-            action=action
+    def format_memory_response(self, fact_id: str, action: str,  fact_content: Optional[str]=None) -> ActionConfirmation:
+        """Formats the action taken for memory"""
+        return ActionConfirmation(
+            id=fact_id,
+            document=fact_content,
+            status=action
         )
 
     def add_facts_from_conversation(self, messages: List, metadata: MemoryMetadata) -> list[str]:
@@ -42,8 +46,8 @@ class MemoryService:
 
         embeddings = self.embedder.generate_embeddings(facts)
 
-        items: List[DBMemoryItem] = [
-            DBMemoryItem(
+        items: List[MemoryInDB] = [
+            MemoryInDB(
                 document=fact,
                 embedding=embeddings[i],
                 metadata=metadata
@@ -70,9 +74,9 @@ class MemoryService:
         memories = []
         for i in range(len(results.get("ids", []))):
             memories.append(
-                MemoryItem(
-                    fact_id=results["ids"][i],
-                    fact=results["documents"][i],
+                MemoryResponse(
+                    id=results["ids"][i],
+                    document=results["documents"][i],
                     metadata=results["metadatas"][i]
                 )
             )
@@ -91,23 +95,23 @@ class MemoryService:
 
         for i in range(len(results.get("ids", []))):
             memories.append(
-                MemoryItem(
-                    fact_id=results["ids"][i],
-                    fact=results["documents"][i],
+                MemoryResponse(
+                    id=results["ids"][i],
+                    document=results["documents"][i],
                     metadata=results["metadatas"][i],
                     similarity=results["distances"][i]
                 )
             )
         return memories
     
-    def create_memories(self, data: MemoryCreateItem):
+    def create_memories(self, data: MemoryCreateRequest):
         """Directly creates memories and adds to DB"""
 
-        facts = data.facts
+        facts = data.documents
         embeddings = self.embedder.generate_embeddings(texts=facts)
 
-        items: List[DBMemoryItem] = [
-            DBMemoryItem(
+        items: List[MemoryInDB] = [
+            MemoryInDB(
                 document=fact,
                 embedding=embeddings[i],
                 metadata=data.metadata
@@ -140,13 +144,15 @@ class MemoryService:
             )
         return response
     
-    def update_memories(self, update_items: List[MemoryUpdateItem]):
+    def update_memories(self, update_items: List[MemoryUpdateRequest]):
         """Updates memory with given id and fact content"""
         new_facts = [items.document for items in update_items]
         new_embeddings = self.embedder.generate_embeddings(texts=new_facts)
 
-        items: List[DBMemoryItem] = [
-            DBMemoryItem(
+        # TODO: Partial update is allowed, either document or metadata or both
+        # should update only those that are provided, validate if id exists as well
+        items: List[MemoryInDB] = [
+            MemoryInDB(
                 id=update_item.id,
                 document=update_item.document,
                 embedding=new_embeddings[i],

--- a/src/memsrv/db/adapters/chroma.py
+++ b/src/memsrv/db/adapters/chroma.py
@@ -1,8 +1,7 @@
 """Chroma db implementation"""
 import chromadb
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any
 from memsrv.db.base_adapter import VectorDBAdapter
-from memsrv.models.memory import DBMemoryItem
 
 class ChromaDBAdapter(VectorDBAdapter):
     """Implements vector db ops for chroma DB"""
@@ -80,7 +79,7 @@ class ChromaDBAdapter(VectorDBAdapter):
         )
         return results
 
-    def query_by_similarity(self, collection_name, query_embedding, query_text, filters, top_k):
+    def query_by_similarity(self, collection_name, query_embedding, query_text=None, filters=None, top_k=20):
         """Retreive items similar to query with optional filters"""
 
         collection = self.client.get_collection(name=collection_name)

--- a/src/memsrv/db/adapters/chroma.py
+++ b/src/memsrv/db/adapters/chroma.py
@@ -1,7 +1,11 @@
 """Chroma db implementation"""
-import chromadb
 from typing import Dict, Any
+import chromadb
+from memsrv.utils.logger import get_logger
 from memsrv.db.base_adapter import VectorDBAdapter
+from memsrv.db.utils import serialize_items
+
+logger = get_logger(__name__)
 
 class ChromaDBAdapter(VectorDBAdapter):
     """Implements vector db ops for chroma DB"""
@@ -20,7 +24,8 @@ class ChromaDBAdapter(VectorDBAdapter):
     def _format_filters(self, filters: Dict[str, Any]) -> Dict[str, Any]:
         """
         Converts simple {k: v} filter dict into Chroma's query format with $and + $eq.
-        This formatter will be implemented for all adapters
+        This formatter will be implemented for all adapters and changes as per
+        the filtering mechanism of each adapter.
         """
         if not filters:
             return {}
@@ -43,52 +48,38 @@ class ChromaDBAdapter(VectorDBAdapter):
         return True
 
     def add(self, collection_name, items):
+        
         collection = self.client.get_collection(name=collection_name)
+        serialized_items = serialize_items(items)
+        
         collection.add(
-            ids=[item.id for item in items],
-            documents=[item.document for item in items],
-            embeddings=[item.embedding for item in items],
-            metadatas=[item.metadata.model_dump() for item in items]
+            ids=serialized_items["ids"],
+            documents=serialized_items["documents"],
+            embeddings=serialized_items["embeddings"],
+            metadatas=serialized_items["metadatas"]
         )
-        print(f"Successfully added {len(items)} items to chroma collection.")
-        return [item.id for item in items]
-    
-    def update(self, collection_name, items):
-        collection = self.client.get_collection(name=collection_name)
-        collection.update(
-            ids=[item.id for item in items],
-            documents=[item.document for item in items],
-            embeddings=[item.embedding for item in items],
-            metadatas=[item.metadata.model_dump() for item in items]
-        )
-        print(f"Successfully updated {len(items)} items to chroma collection.")
-        return [item.id for item in items]
-
-    def delete(self, collection_name, fact_ids):
-        collection = self.client.get_collection(name=collection_name)
-        collection.delete(ids=fact_ids)
-        print(f"Successfully deleted memory with id {fact_ids} from chroma collection")
-        return fact_ids
+        
+        logger.info(f"Successfully added {len(items)} items to chroma collection.")
+        return serialized_items["ids"]
 
     def query_by_filter(self, collection_name, filters, limit):
+        
         collection = self.client.get_collection(name=collection_name)
         where_clause = self._format_filters(filters)
+        
         results = collection.get(
             where=where_clause if where_clause else None,
             limit=limit
         )
+        
+        logger.info(results)
         return results
 
     def query_by_similarity(self, collection_name, query_embedding, query_text=None, filters=None, top_k=20):
-        """Retreive items similar to query with optional filters"""
 
         collection = self.client.get_collection(name=collection_name)
         where_clause = self._format_filters(filters)
 
-        # To keep our adapters clean, we expect embeddings independently
-        # This way any provider can be used with any DB
-        # In some cases for keyword search or to perform Hybrid search
-        # we might use the query text
         results = collection.query(
             query_embeddings=[query_embedding],
             n_results=top_k,
@@ -105,3 +96,26 @@ class ChromaDBAdapter(VectorDBAdapter):
             results["ids"], results["documents"], results["metadatas"], results["distances"] = [], [], [], []
 
         return results
+
+    def update(self, collection_name, items):
+        
+        collection = self.client.get_collection(name=collection_name)
+        serialized_items = serialize_items(items)
+        
+        collection.update(
+            ids=serialized_items["ids"],
+            documents=serialized_items["documents"],
+            embeddings=serialized_items["embeddings"],
+            metadatas=serialized_items["metadatas"]
+        )
+        
+        logger.info(f"Successfully updated {len(items)} items to chroma collection.")
+        return serialized_items["ids"]
+
+    def delete(self, collection_name, fact_ids):
+        
+        collection = self.client.get_collection(name=collection_name)
+        collection.delete(ids=fact_ids)
+        
+        logger.info(f"Successfully deleted memory with id {fact_ids} from chroma collection")
+        return fact_ids

--- a/src/memsrv/db/adapters/postgres.py
+++ b/src/memsrv/db/adapters/postgres.py
@@ -1,11 +1,10 @@
 """Postgres with pgvector implementation"""
 import os
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 import logging
 
 from sqlalchemy import create_engine, text, exc
 from memsrv.db.base_adapter import VectorDBAdapter
-from memsrv.models.memory import DBMemoryItem
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/src/memsrv/db/base_adapter.py
+++ b/src/memsrv/db/base_adapter.py
@@ -1,7 +1,7 @@
 """Abstract class to add, query to vector DB"""
 from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional
-from memsrv.models.memory import DBMemoryItem
+from memsrv.models.memory import MemoryInDB
 
 class VectorDBAdapter(ABC):
     """Abstract interface for any vector DB provider."""
@@ -13,12 +13,12 @@ class VectorDBAdapter(ABC):
         pass
 
     @abstractmethod
-    def add(self, collection_name: str, items: List[DBMemoryItem]) -> List[str]:
+    def add(self, collection_name: str, items: List[MemoryInDB]) -> List[str]:
         """Add items (facts + metadata) into a collection."""
         pass
     
     @abstractmethod
-    def update(self, collection_name: str, items: List[DBMemoryItem]):
+    def update(self, collection_name: str, items: List[MemoryInDB]):
         """Updates items at given with new data, fact_id should be provided"""
         pass
 

--- a/src/memsrv/db/utils.py
+++ b/src/memsrv/db/utils.py
@@ -1,0 +1,29 @@
+"""Common utils for db adapters"""
+from typing import List, Dict, Any
+from memsrv.models.memory import MemoryInDB
+
+def serialize_items(items: List[MemoryInDB], include_system_fields: bool = True) -> Dict[str, Any]:
+    """Converts a list of MemoryInDB into structured arrays for DB adapters."""
+    ids = []
+    documents = []
+    embeddings = []
+    metadatas = []
+
+    for item in items:
+        ids.append(item.id)
+        documents.append(item.document)
+        embeddings.append(item.embedding)
+
+        metadata_dict = item.metadata.model_dump()
+        if include_system_fields:
+            metadata_dict["created_at"] = item.created_at
+            metadata_dict["updated_at"] = item.updated_at
+
+        metadatas.append(metadata_dict)
+
+    return {
+        "ids": ids,
+        "documents": documents,
+        "embeddings": embeddings,
+        "metadatas": metadatas,
+    }

--- a/src/memsrv/embeddings/providers/gemini.py
+++ b/src/memsrv/embeddings/providers/gemini.py
@@ -3,7 +3,10 @@ import os
 from typing import List
 from google.genai.client import Client as geminiClient
 from google.genai.types import EmbedContentConfig
+from memsrv.utils.logger import get_logger
 from memsrv.embeddings.base_embedder import BaseEmbedding
+
+logger = get_logger(__name__)
 
 class GeminiEmbedding(BaseEmbedding):
     """Embedding module for generating embeddings using gemini api"""
@@ -28,5 +31,5 @@ class GeminiEmbedding(BaseEmbedding):
                 embedding_result.append(embedding.values)
             return embedding_result
         except Exception as e:
-            print(f"An error occurred during embedding generation: {e}")
+            logger.error(f"An error occurred during embedding generation: {e}")
             return [[] for _ in texts]

--- a/src/memsrv/models/memory.py
+++ b/src/memsrv/models/memory.py
@@ -17,7 +17,20 @@ class MemoryMetadata(BaseModel):
     app_id: str = Field(description="ID of the application acting as client for memory service.")
     session_id: str = Field(description="ID of the session to attach to the memory.")
     agent_name: str = Field(description="Name of the agent which is adding the memory or events originating from.")
-    event_timestamp: Optional[str] = Field(default_factory=get_current_time, description="Time when the event occured in ISO format")
+    event_timestamp: Optional[str] = Field(default_factory=get_current_time, description="Time when the event occured in ISO format, if not provided server timestamp will be used")
+
+    def filterable_dict(self) -> dict:
+        """Return only the fields that can be used for filtering.
+        This will help as the metadata fields grow
+        Not used for now, since filters are get params now
+        and partial values are allowed and timestamp_is not * field
+        """
+        return {
+            "user_id": self.user_id,
+            "app_id": self.app_id,
+            "session_id": self.session_id,
+            "agent_name": self.agent_name,
+        }
 
 class MemoryInDB(BaseModel):
     """A single memory record as stored in the database."""

--- a/src/memsrv/models/memory.py
+++ b/src/memsrv/models/memory.py
@@ -1,54 +1,29 @@
 """data models for facts, memories and api services will be added here"""
 import uuid
+from datetime import datetime, timezone
 from pydantic import BaseModel, Field
-from typing import Optional, Dict, List, Any, Literal
+from typing import Optional, List
 
 # TODO: add timestamps as well
+def get_current_time():
+    """Gets current UTC time in iso format"""
+    # add offset based on timezone if needed
+    return datetime.now(timezone.utc).isoformat()
 
 class MemoryMetadata(BaseModel):
-    user_id: str
-    app_id: str
-    session_id: str
-    timestamp: Optional[str] = ""
-    agent_name: str
+    """Metadata attached to a memory"""
+    # we can use timestamp to track direct memory creation by llm using tools in same session
+    user_id: str = Field(description="ID of the user to attach the memory to. e.g, user@email.com, u_123")
+    app_id: str = Field(description="ID of the application acting as client for memory service.")
+    session_id: str = Field(description="ID of the session to attach to the memory.")
+    agent_name: str = Field(description="Name of the agent which is adding the memory or events originating from.")
+    event_timestamp: Optional[str] = Field(default_factory=get_current_time, description="Time when the event occured in ISO format")
 
-class DBMemoryItem(BaseModel):
+class MemoryInDB(BaseModel):
+    """A single memory record as stored in the database."""
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     document: str
     embedding: List[float]
     metadata: MemoryMetadata
-
-# TODO: update with more fields as per design
-class MemoryItem(BaseModel):
-    fact_id: str
-    fact: str
-    metadata: Dict[str, Any]
-    similarity: Optional[float] = 0.0
-
-class MemoryCreateItem(BaseModel):
-    facts: List[str]
-    metadata: MemoryMetadata
-
-class MemoryUpdateItem(BaseModel):
-    id: str
-    document: str
-    metadata: MemoryMetadata
-
-class GetMemoriesResponseModel(BaseModel):
-    memories: List[MemoryItem]
-
-class MemoryResponseData(BaseModel):
-    id: str
-    content: Optional[str]
-
-class MemoryActionResponse(BaseModel):
-    memory: MemoryResponseData
-    action: Literal["CREATED", "UPDATED", "DELETED"]
-
-class AddMemoriesResponseModel(BaseModel):
-    message: str
-    info: List[MemoryActionResponse]
-
-class DeleteMemoriesResponseModel(BaseModel):
-    message: str
-    info: List[MemoryActionResponse]
+    created_at: str = Field(default_factory=get_current_time)
+    updated_at: str = Field(default_factory=get_current_time)

--- a/src/memsrv/models/request.py
+++ b/src/memsrv/models/request.py
@@ -1,6 +1,7 @@
 """API Request data models"""
 from pydantic import BaseModel, Field
 from typing import Optional, Dict, List, Any
+from pydantic.config import ConfigDict
 
 from memsrv.models.memory import MemoryMetadata
 
@@ -12,13 +13,44 @@ class MemoryCreateRequest(BaseModel):
     documents: List[str] = Field(..., min_length=1, description="The text content of memory to add to memory service.")
     metadata: MemoryMetadata
 
+    model_config = ConfigDict(json_schema_extra={
+        "examples": [{
+            "documents": ["I like john wick", "I love watching action movies"],
+            "metadata": {
+                "user_id": "user@email.com",
+                "app_id": "swagger",
+                "session_id": "s123",
+                "agent_name": "custom_agent",
+                "event_timestamp": "2025-08-29T17:35:10.557Z"
+            }
+        }]
+    })
+
 class MemoryGenerateRequest(BaseModel):
     """
     Model for the /memories/generate endpoint.
     Client provides conversation history and shared metadata.
     """
-    messages: List[Dict[str, Any]] = Field(description="List of messages altering between user and model as list role, parts")
+    messages: List[Dict[str, Any]] = Field(..., min_length=2, description="List of messages altering between user and model as list role, parts")
     metadata: MemoryMetadata
+
+    model_config = ConfigDict(json_schema_extra={
+        "examples": [{
+            "messages": [
+                { "role": "user", "parts": [{ "text": "hello" }]},
+                { "role": "model", "parts": [{ "text": "Hello! How can I help you today?\n" }]},
+                { "role": "user", "parts": [{ "text": "my name is ruths, i like action movies" }]},
+                { "role": "model", "parts": [{"text": "Nice to meet you, Ruths. I like helping people. Do you have any questions for me?\n"}]}
+            ],
+            "metadata": {
+                "user_id": "user@email.com",
+                "app_id": "swagger",
+                "session_id": "s123",
+                "agent_name": "custom_agent",
+                "event_timestamp": "2025-08-29T17:35:10.557Z"
+            }
+        }]
+    })
 
 class MemoryUpdateRequest(BaseModel):
     """
@@ -27,5 +59,19 @@ class MemoryUpdateRequest(BaseModel):
     Fields are optional to allow partial updates.
     """
     id: str = Field(description="ID of the memory to update")
-    document: Optional[str] = None
+    document: Optional[str] = Field(default=None, description="Memory text to update the existing one.")
     metadata: Optional[MemoryMetadata] = None
+
+    model_config = ConfigDict(json_schema_extra={
+        "examples": [{
+            "id": "be94116b-6817-4e87-b490-4adae1d7824b",
+            "document": "I like action movies without CGI.",
+            "metadata": {
+                "user_id": "user@email.com",
+                "app_id": "swagger",
+                "session_id": "s123",
+                "agent_name": "custom_agent",
+                "event_timestamp": "2025-08-29T17:35:10.557Z"
+            }
+        }]
+    })

--- a/src/memsrv/models/request.py
+++ b/src/memsrv/models/request.py
@@ -1,0 +1,31 @@
+"""API Request data models"""
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, List, Any
+
+from memsrv.models.memory import MemoryMetadata
+
+class MemoryCreateRequest(BaseModel):
+    """
+    Model for the /memories/create endpoint.
+    Client provides a list of documents and shared metadata.
+    """
+    documents: List[str] = Field(..., min_length=1, description="The text content of memory to add to memory service.")
+    metadata: MemoryMetadata
+
+class MemoryGenerateRequest(BaseModel):
+    """
+    Model for the /memories/generate endpoint.
+    Client provides conversation history and shared metadata.
+    """
+    messages: List[Dict[str, Any]] = Field(description="List of messages altering between user and model as list role, parts")
+    metadata: MemoryMetadata
+
+class MemoryUpdateRequest(BaseModel):
+    """
+    Model for the /memories/update endpoint.
+    Client provides the ID of the memory and the fields to update.
+    Fields are optional to allow partial updates.
+    """
+    id: str = Field(description="ID of the memory to update")
+    document: Optional[str] = None
+    metadata: Optional[MemoryMetadata] = None

--- a/src/memsrv/models/response.py
+++ b/src/memsrv/models/response.py
@@ -1,0 +1,31 @@
+"""API response data models"""
+from pydantic import BaseModel
+from typing import Optional, List, Literal
+
+from memsrv.models.memory import MemoryMetadata
+
+class MemoryResponse(BaseModel):
+    """Model for a single memory returned to the client."""
+    id: str
+    document: str
+    metadata: MemoryMetadata
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    similarity: Optional[float] = None
+
+class GetMemoriesResponse(BaseModel):
+    """Response model for any query that returns a list of memories."""
+    memories: List[MemoryResponse]
+
+class ActionConfirmation(BaseModel):
+    """A generic confirmation for a successfully performed action on a memory."""
+    # document here is for debugging, will be removed later since we might not
+    # want to expose it in api response
+    id: str
+    document: Optional[str] = None
+    status: Literal["CREATED", "UPDATED", "DELETED"]
+
+class MemoriesActionResponse(BaseModel):
+    """A generic response model for Create, Update, Delete operations."""
+    message: str
+    info: List[ActionConfirmation]

--- a/src/memsrv/utils/logger.py
+++ b/src/memsrv/utils/logger.py
@@ -1,0 +1,12 @@
+"""Common logger"""
+import logging
+
+# Configure logging once, globally
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S"
+)
+
+def get_logger(name: str):
+    return logging.getLogger(name)


### PR DESCRIPTION
Changelog:
1. Refactor all datamodels to be more standard and reusable. Seperate them to memory, requests and responses.
2. Update chroma and postgres to use the standard datamodels and read data accordingly.
3. Update apis and core services to use these datamodels
4. Add update and delete methods for postgres.
    - Partial updates are not present now, need to implement later.
5. Add examples for request datamodels in swagger.
6. Use standardized logger for all files instead of importing in all files.