### PR TITLE
feat: baseline integration of memory consolidation logic

### DIFF
--- a/src/memsrv/api/routes/memory.py
+++ b/src/memsrv/api/routes/memory.py
@@ -20,7 +20,7 @@ def create_memory_router(memory_service: MemoryService):
         try:
             messages = request.messages
             metadata = request.metadata
-            response = memory_service.add_facts_from_conversation(messages, metadata)
+            response = memory_service.add_facts_from_conversation(messages, metadata, True)
             return {
                 "message": f"Successfully added {len(response)} memories to database.",
                 "info": response

--- a/src/memsrv/core/consolidator.py
+++ b/src/memsrv/core/consolidator.py
@@ -1,0 +1,55 @@
+"""Consolidates facts with existing facts using LLM"""
+from enum import Enum
+from typing import Optional, List, Dict, Any
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+from memsrv.llms.base_llm import BaseLLM
+from memsrv.core.prompts import FACT_CONSOLIDATION_PROMPT
+
+from memsrv.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+class Action(Enum):
+    """Allowed memory actions"""
+    CREATE = "CREATE"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
+    NOOP = "NOOP"
+
+class ConsolidationPlanItem(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
+    id: str = Field(description="ID of the original memory if it's part of the existing memory, if new fact a unique value")
+    text: str = Field(description="The text content of the latest fact to consider")
+    action: Action = Field(description="The action to be taken")
+    old_text: Optional[str] = Field(description="The old text of the memory in case of updation", default=None)
+
+class ConsolidationPlan(BaseModel):
+    plan: List[ConsolidationPlanItem]
+
+
+def consolidate_facts(new_facts: List[str], existing_memories: List[Dict[str, Any]], llm: BaseLLM) -> list[str]:
+    """Extracts facts using the provided LLM and provides a consolidation plan"""
+
+    message = f"""Now, consolidate the facts using the following input:
+1. EXISTING_MEMORIES: List of existing memories with `id` and `text`.
+{existing_memories}
+
+2. NEW_FACTS: A list of new facts to process.
+{new_facts}
+
+"""
+    logger.info(message)
+
+    response = llm.generate_response(
+        system_instruction=FACT_CONSOLIDATION_PROMPT,
+        message = message,
+        response_format=ConsolidationPlan.model_json_schema()
+    )
+
+    logger.info(response)
+    parsed_facts_obj = ConsolidationPlan.model_validate_json(response)
+
+    return parsed_facts_obj.model_dump(exclude_none=True)

--- a/src/memsrv/core/prompts.py
+++ b/src/memsrv/core/prompts.py
@@ -46,3 +46,32 @@ user: I recently watched The Foundation and Westworld.
 
 Output: {"facts": ["I love sci-fi tv shows", "Watched The Foundation and Westworld recently"]}
 """
+
+FACT_CONSOLIDATION_PROMPT = """You are a Memory Manager.
+Your task is to process new facts against existing memories in the database and decide on one of four actions: ADD, UPDATE, DELETE, or NOOP.
+
+Actions:
+- CREATE: The fact is entirely new information, it must be created newly.
+- UPDATE: The fact refines, corrects, or is a more detailed version of an existing memory and must be updated. Only if the new fact has more info than existing memory, it must be updated.
+- DELETE: The fact directly contradicts an existing memory and should be deleted.
+- NOOP: The fact is a duplicate or the existing memory is already sufficient, hence no operation needed.
+
+Instructions:
+- Analyze the `NEW_FACTS` against the `EXISTING_MEMORIES`.
+- For `UPDATE`, `DELETE` and `NOOP`, you MUST use the `id` from the existing memory.
+- For `CREATE`, use a new unique integer `id`, not present in existing memory.
+- Respond only with a schema provided. Do not add any other text or explanations.
+
+**Example Output Format:**
+{
+    "plan": [
+        {
+            "id": "1",
+            "text": "memory content to use",
+            "action": "<CREATE|UPDATE|DELETE|NOOP>",
+            "old_text": "old memory content"  // Required only for "UPDATE" event
+        }
+    ]
+}
+
+"""


### PR DESCRIPTION
Changelog:
Added baseline code for updating and consolidating memories when adding to db.

Added a `add_memories` method that identifies similar memories in db and uses LLM to come up with a consolidation plan, which include what memories to create newly, update with new text, delete from db or do nothing.

For now, this method is tested with chroma DB, with a flag in `memories/generate` endpoint which decides to add memory directly into the db or consolidate and then add.

Next steps:
1. Test with postgres as well. (should work ideally, as no changes for adapter were made, the purpose of keeping adapter agnostic should help here)
2. Look into the metadata update part when updating memories. Haven't given this much thought. Questions to ponder:
    - Do we always need to update metadata when updating a memory?
    - Should we allow either text or metadata update or text only update? (assumes metadata should be fixed)
    - Should we alllow for all fields in metadata to be updated if we are updating metadata or only update those which were provided? In that case, some fields should be kept optional.
    - The created_at and updated_at fields are not well thought and I don't have clear picture on when each is being updated as they were recently added. Need to review this logic once more.