### PR TITLE
Feat: memory consolidation with bulk updates and searches

### DIFF
--- a/src/memsrv/api/routes/memory.py
+++ b/src/memsrv/api/routes/memory.py
@@ -101,6 +101,7 @@ def create_memory_router(memory_service: MemoryService):
     def update_memories(items: List[MemoryUpdateRequest]):
         """Updates memories for given items"""
         try:
+            # TODO: Add check by id here before proceeding to update and extend the list
             response = memory_service.update_memories(update_items=items)
             return {
                 "message": f"Successfully updated {len(response)} memories in the database.",
@@ -114,6 +115,7 @@ def create_memory_router(memory_service: MemoryService):
     def delete_memories(ids: List[str]):
         """Deletes memories from database for given ids"""
         try:
+            # TODO: Add check by id here before proceeding to delete and extend the list
             response = memory_service.delete_memories(memory_ids=ids)
             return {
                 "message": f"Successfully deleted {len(response)} memories from database.",

--- a/src/memsrv/api/routes/memory.py
+++ b/src/memsrv/api/routes/memory.py
@@ -76,7 +76,7 @@ def create_memory_router(memory_service: MemoryService):
             if app_id:
                 filters["app_id"] = app_id
 
-            memories = memory_service.search_memories_by_similarity(query=query,
+            memories = memory_service.search_memories_by_similarity(query_texts=query,
                                                                     filters=filters,
                                                                     limit=limit)
             return GetMemoriesResponse(memories=memories)

--- a/src/memsrv/core/memory_service.py
+++ b/src/memsrv/core/memory_service.py
@@ -1,5 +1,5 @@
 """To add MemoryService class to add facts and to db services"""
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Union
 
 from memsrv.core.extractor import parse_messages, extract_facts
 from memsrv.llms.base_llm import BaseLLM
@@ -72,27 +72,35 @@ class MemoryService:
         
         return memories
     
-    def search_memories_by_similarity(self, query: str, filters: Dict[str, Any] = None, limit: int = 20):
+    def search_memories_by_similarity(self, query_texts: Union[str, List[str]], filters: Dict[str, Any] = None, limit: int = 20):
         """Queries vector db and get memories similar to query and applies filters"""
-        query_embedding = self.embedder.generate_embeddings(texts=[query])
+        if isinstance(query_texts, str):
+            query_texts = [query_texts]
+        query_embeddings = self.embedder.generate_embeddings(texts=query_texts)
 
         results = self.db.query_by_similarity(collection_name="memories",
-                                              query_embedding=query_embedding[0],
+                                              query_embeddings=query_embeddings,
                                               filters=filters,
                                               top_k=limit)
         memories = []
 
-        for i in range(len(results.get("ids", []))):
-            memories.append(
-                MemoryResponse(
-                    id=results["ids"][i],
-                    document=results["documents"][i],
-                    metadata=results["metadatas"][i],
-                    similarity=results["distances"][i],
-                    created_at=results["metadatas"][i].get("created_at"),
-                    updated_at=results["metadatas"][i].get("updated_at")
+        for query_index in range(len(query_texts)):
+            ids = results["ids"][query_index]
+            documents = results["documents"][query_index]
+            metadatas = results["metadatas"][query_index]
+            distances = results["distances"][query_index]
+
+            for i in range(len(ids)):
+                memories.append(
+                    MemoryResponse(
+                        id=ids[i],
+                        document=documents[i],
+                        metadata=metadatas[i],
+                        similarity=distances[i],
+                        created_at=metadatas[i].get("created_at"),
+                        updated_at=metadatas[i].get("updated_at")
+                    )
                 )
-            )
         return memories
     
     def create_memories(self, data: MemoryCreateRequest):
@@ -166,26 +174,20 @@ class MemoryService:
     def add_memories(self, facts: List[str], metadata: MemoryMetadata):
         """Adds memories to db after consolidating them"""
 
+        filters = metadata.filterable_dict()
+        similar_memories = self.search_memories_by_similarity(
+            query_texts=facts,
+            filters=filters,
+            limit=3
+        )
+        
         similar_memories_dict = {}
-        # TODO: Use batch similarity requests here
-        # Since we can batch embed facts and batch query(chroma)
-        # this seems to be most optmized path rather than embed and query
-        # for each item
-        for fact in facts:
-            # For each fact find top 3 similar memories
-            similar_memories = self.search_memories_by_similarity(
-                query=fact,
-                filters=metadata.filterable_dict(),
-                limit=3
-            )
-
-            for similar_memory in similar_memories:
-                # Add each existing memory to a dict and avoid repetition
-                if similar_memory.id not in similar_memories_dict:
-                    similar_memories_dict[similar_memory.id] = {
-                        "id": similar_memory.id,
-                        "document": similar_memory.document
-                    }
+        for memory in similar_memories:
+            if memory.id not in similar_memories_dict:
+                similar_memories_dict[memory.id] = {
+                    "id": memory.id,
+                    "document": memory.document
+                }
         
         similar_memory_items = list(similar_memories_dict.values())
 
@@ -225,7 +227,7 @@ class MemoryService:
                         MemoryUpdateRequest(
                             id=original_id,
                             document=text
-                            # Ignore metadata for update
+                            # YAGNI: Ignore metadata for update
                             # create new one if needed
                         )
                     )

--- a/src/memsrv/db/adapters/chroma.py
+++ b/src/memsrv/db/adapters/chroma.py
@@ -61,6 +61,14 @@ class ChromaDBAdapter(VectorDBAdapter):
         
         logger.info(f"Successfully added {len(items)} items to chroma collection.")
         return serialized_items["ids"]
+    
+    def get_by_ids(self, collection_name, ids):
+
+        collection = self.client.get_collection(name=collection_name)
+
+        result = collection.get(ids=ids)
+
+        return result
 
     def query_by_filter(self, collection_name, filters, limit):
         
@@ -100,17 +108,20 @@ class ChromaDBAdapter(VectorDBAdapter):
     def update(self, collection_name, items):
         
         collection = self.client.get_collection(name=collection_name)
-        serialized_items = serialize_items(items)
+        ids_to_update = [item.id for item in items]
+        documents = [item.document for item in items]
+        embeddings = [item.embedding for item in items]
+        metadatas = [{"updated_at": item.updated_at} for item in items]
         
         collection.update(
-            ids=serialized_items["ids"],
-            documents=serialized_items["documents"],
-            embeddings=serialized_items["embeddings"],
-            metadatas=serialized_items["metadatas"]
+            ids=ids_to_update,
+            documents=documents,
+            embeddings=embeddings,
+            metadatas=metadatas
         )
         
         logger.info(f"Successfully updated {len(items)} items to chroma collection.")
-        return serialized_items["ids"]
+        return ids_to_update
 
     def delete(self, collection_name, fact_ids):
         

--- a/src/memsrv/db/adapters/chroma.py
+++ b/src/memsrv/db/adapters/chroma.py
@@ -79,30 +79,20 @@ class ChromaDBAdapter(VectorDBAdapter):
             where=where_clause if where_clause else None,
             limit=limit
         )
-        
-        logger.info(results)
+
         return results
 
-    def query_by_similarity(self, collection_name, query_embedding, query_text=None, filters=None, top_k=20):
+    def query_by_similarity(self, collection_name, query_embeddings, query_texts=None, filters=None, top_k=20):
 
         collection = self.client.get_collection(name=collection_name)
         where_clause = self._format_filters(filters)
 
         results = collection.query(
-            query_embeddings=[query_embedding],
+            query_embeddings=query_embeddings,
             n_results=top_k,
             where=where_clause if where_clause else None
         )
-        # Chroma supports multi queries in one call, so returns as a list of vals
-        # Since we are currently running a single query, we take the first result
-        if results.get("ids"):
-            results["ids"] = results["ids"][0]
-            results["documents"] = results["documents"][0]
-            results["metadatas"] = results["metadatas"][0]
-            results["distances"] = results["distances"][0]
-        else:
-            results["ids"], results["documents"], results["metadatas"], results["distances"] = [], [], [], []
-
+        
         return results
 
     def update(self, collection_name, items):

--- a/src/memsrv/db/base_adapter.py
+++ b/src/memsrv/db/base_adapter.py
@@ -38,6 +38,6 @@ class VectorDBAdapter(ABC):
         pass
 
     @abstractmethod
-    def query_by_similarity(self, collection_name: str, query_embedding: List[float],  query_text: Optional[str] = None, filters: Optional[Dict[str, Any]] = None, top_k: int = 20):
+    def query_by_similarity(self, collection_name: str, query_embeddings: List[List[float]],  query_texts: List[Optional[str]] = None, filters: Optional[Dict[str, Any]] = None, top_k: int = 20):
         """Query items by text with optional filters."""
         pass

--- a/src/memsrv/db/base_adapter.py
+++ b/src/memsrv/db/base_adapter.py
@@ -1,7 +1,7 @@
 """Abstract class to add, query to vector DB"""
 from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional
-from memsrv.models.memory import MemoryInDB
+from memsrv.models.memory import MemoryInDB, MemoryUpdatePayload
 
 class VectorDBAdapter(ABC):
     """Abstract interface for any vector DB provider."""
@@ -18,13 +18,18 @@ class VectorDBAdapter(ABC):
         pass
     
     @abstractmethod
-    def update(self, collection_name: str, items: List[MemoryInDB]):
+    def update(self, collection_name: str, items: List[MemoryUpdatePayload]):
         """Updates items at given with new data, fact_id should be provided"""
         pass
 
     @abstractmethod
     def delete(self, collection_name: str, fact_ids: List[str]):
         """Deletes items with provided id"""
+        pass
+
+    @abstractmethod
+    def get_by_ids(self, collection_name: str, ids: List[str]):
+        """Get memory items by ids"""
         pass
 
     @abstractmethod

--- a/src/memsrv/models/memory.py
+++ b/src/memsrv/models/memory.py
@@ -40,3 +40,12 @@ class MemoryInDB(BaseModel):
     metadata: MemoryMetadata
     created_at: str = Field(default_factory=get_current_time)
     updated_at: str = Field(default_factory=get_current_time)
+
+class MemoryUpdatePayload(BaseModel):
+    """
+    Internal structure for passing a prepared memory update to a DB adapter.
+    """
+    id: str
+    document: str
+    embedding: List[float]
+    updated_at: str = Field(default_factory=get_current_time)

--- a/src/memsrv/models/memory.py
+++ b/src/memsrv/models/memory.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, Field
 from typing import Optional, List
 
-# TODO: add timestamps as well
 def get_current_time():
     """Gets current UTC time in iso format"""
     # add offset based on timezone if needed

--- a/src/memsrv/models/request.py
+++ b/src/memsrv/models/request.py
@@ -56,22 +56,13 @@ class MemoryUpdateRequest(BaseModel):
     """
     Model for the /memories/update endpoint.
     Client provides the ID of the memory and the fields to update.
-    Fields are optional to allow partial updates.
     """
     id: str = Field(description="ID of the memory to update")
-    document: Optional[str] = Field(default=None, description="Memory text to update the existing one.")
-    metadata: Optional[MemoryMetadata] = None
+    document: str = Field(default=None, description="Memory text to update the existing one.")
 
     model_config = ConfigDict(json_schema_extra={
         "examples": [{
             "id": "be94116b-6817-4e87-b490-4adae1d7824b",
-            "document": "I like action movies without CGI.",
-            "metadata": {
-                "user_id": "user@email.com",
-                "app_id": "swagger",
-                "session_id": "s123",
-                "agent_name": "custom_agent",
-                "event_timestamp": "2025-08-29T17:35:10.557Z"
-            }
+            "document": "I like action movies without CGI."
         }]
     })

--- a/src/memsrv/models/request.py
+++ b/src/memsrv/models/request.py
@@ -55,7 +55,7 @@ class MemoryGenerateRequest(BaseModel):
 class MemoryUpdateRequest(BaseModel):
     """
     Model for the /memories/update endpoint.
-    Client provides the ID of the memory and the fields to update.
+    Client provides the ID of the memory and the content to update.
     """
     id: str = Field(description="ID of the memory to update")
     document: str = Field(default=None, description="Memory text to update the existing one.")

--- a/src/memsrv/models/response.py
+++ b/src/memsrv/models/response.py
@@ -23,7 +23,7 @@ class ActionConfirmation(BaseModel):
     # want to expose it in api response
     id: str
     document: Optional[str] = None
-    status: Literal["CREATED", "UPDATED", "DELETED"]
+    status: Literal["CREATED", "UPDATED", "DELETED", "NOT_FOUND"]
 
 class MemoriesActionResponse(BaseModel):
     """A generic response model for Create, Update, Delete operations."""


### PR DESCRIPTION
Resolves the issues mentioned in #11 towards the end.
Changelog:
1. Modified the `updated_memories` function to update memories, assuming the metadata will remain the same.
    - Partial updates were allowed before, but this has two drawbacks.
         - ID was being provided, so we need to fetch the actual metadata if not provided.(additonal db call)
         - If only some metadata fields are allowed to update, additional logic is needed to compare.
     - So, the final idea was to abandon the partial updates. If there is a need to modify metadata, it's simple and cleaner to create a new memory with this data and delete the old one if not needed. **You Ain't Gonna Need It** - This just adds additional management and the adapter code get's messy. It's just unncessary complexity in the code.
     - This made the update memory logic simple, provide an id and memory content to update and we'll make these changes. We'll update the update_at time. This is just simple, clean and enough, get's the work done and optimized.
2. Modified the `search_by_similarity` to perform bulk searches on the vectorDBs. Chroma already supports this, but for postgres, we just iterate and run them sequentially. Porting to async should make this faster later. As discussed in #7 .
3. Updated the `add_memories` method to use the bulk search option, making initial similarity search to identify existing memories much faster.