### PR TITLE
chore: Make db query ops more modular

### DIFF
--- a/src/memsrv/api/routes/memory.py
+++ b/src/memsrv/api/routes/memory.py
@@ -114,14 +114,14 @@ def create_memory_router(memory_service: MemoryService):
         try:
             results = await memory_service.get_memories_by_ids(memory_ids=ids)
             memories = []
-            for i in range(len(results.get("ids", []))):
+            for i in range(len(results.ids[0])):
                 memories.append(
                     MemoryResponse(
-                        id=results["ids"][i],
-                        document=results["documents"][i],
-                        metadata=results["metadatas"][i],
-                        created_at=results["metadatas"][i].get("created_at"),
-                        updated_at=results["metadatas"][i].get("updated_at")
+                        id=results.ids[0][i],
+                        document=results.documents[0][i],
+                        metadata=results.metadatas[0][i],
+                        created_at=results.metadatas[0][i].get("created_at"),
+                        updated_at=results.metadatas[0][i].get("updated_at")
                     )
                 )
             return GetMemoriesResponse(memories=memories)

--- a/src/memsrv/core/memory_service.py
+++ b/src/memsrv/core/memory_service.py
@@ -254,7 +254,7 @@ class MemoryService:
         partial_failure = False
         # TODO: check if set operation speeds up things here
         for item in update_items:
-            if item.id in existing_ids["ids"]:
+            if item.id in existing_ids.ids[0]:
                 items_to_update.append(MemoryUpdateRequest(
                     id=item.id,
                     document=item.document
@@ -298,7 +298,7 @@ class MemoryService:
         partial_failure = False
         # TODO: check if set operation speeds up things here
         for mem_id in memory_ids:
-            if mem_id in existing_ids["ids"]:
+            if mem_id in existing_ids.ids[0]:
                 ids_to_delete.append(mem_id)
             else:
                 partial_failure = True
@@ -320,15 +320,16 @@ class MemoryService:
 
         results = await self.db.query_by_filter(filters=filters,
                                                 limit=limit)
+        
         memories = []
-        for i in range(len(results.get("ids", []))):
+        for i in range(len(results.ids[0])):
             memories.append(
                 MemoryResponse(
-                    id=results["ids"][i],
-                    document=results["documents"][i],
-                    metadata=results["metadatas"][i],
-                    created_at=results["metadatas"][i].get("created_at"),
-                    updated_at=results["metadatas"][i].get("updated_at")
+                    id=results.ids[0][i],
+                    document=results.documents[0][i],
+                    metadata=results.metadatas[0][i],
+                    created_at=results.metadatas[0][i].get("created_at"),
+                    updated_at=results.metadatas[0][i].get("updated_at")
                 )
             )
 
@@ -339,7 +340,8 @@ class MemoryService:
                                       filters: Dict[str, Any] = None,
                                       limit: int = 20):
         """Queries vector db and get memories similar to query and applies filters"""
-
+        # Note: Since this accepts bulk operation, it should result in
+        # [results1, results2...] but we just add everything to a single list for now
         if isinstance(query_texts, str):
             query_texts = [query_texts]
 
@@ -351,10 +353,10 @@ class MemoryService:
         memories = []
 
         for query_index in range(len(query_texts)): # pylint: disable=consider-using-enumerate
-            ids = results["ids"][query_index]
-            documents = results["documents"][query_index]
-            metadatas = results["metadatas"][query_index]
-            distances = results["distances"][query_index]
+            ids = results.ids[query_index]
+            documents = results.documents[query_index]
+            metadatas = results.metadatas[query_index]
+            distances = results.distances[query_index]
 
             for i in range(len(ids)): # pylint: disable=consider-using-enumerate
                 memories.append(

--- a/src/memsrv/db/adapters/chroma.py
+++ b/src/memsrv/db/adapters/chroma.py
@@ -5,6 +5,7 @@ import chromadb
 from memsrv.utils.logger import get_logger
 from memsrv.db.base_adapter import VectorDBAdapter
 from memsrv.db.utils import serialize_items
+from memsrv.models.response import QueryResponse
 
 logger = get_logger(__name__)
 
@@ -78,9 +79,13 @@ class ChromaDBAdapter(VectorDBAdapter):
 
         collection = self.client.get_collection(name=self.collection_name)
 
-        result = collection.get(ids=ids)
+        results = collection.get(ids=ids)
 
-        return result
+        return QueryResponse(
+            ids=[results.get("ids", [])],
+            documents=[results.get("documents", [])],
+            metadatas=[results.get("metadatas", [])]
+        )
 
     async def query_by_filter(self, filters, limit):
 
@@ -92,7 +97,11 @@ class ChromaDBAdapter(VectorDBAdapter):
             limit=limit
         )
 
-        return results
+        return QueryResponse(
+            ids=[results.get("ids", [])],
+            documents=[results.get("documents", [])],
+            metadatas=[results.get("metadatas", [])]
+        )
 
     async def query_by_similarity(self,
                                   query_embeddings,
@@ -109,7 +118,12 @@ class ChromaDBAdapter(VectorDBAdapter):
             where=where_clause if where_clause else None
         )
 
-        return results
+        return QueryResponse(
+            ids=results.get("ids", []),
+            documents=results.get("documents", []),
+            metadatas=results.get("metadatas", []),
+            distances=results.get("distances", [])
+        )
 
     async def update(self, items):
 

--- a/src/memsrv/db/base_adapter.py
+++ b/src/memsrv/db/base_adapter.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional
 from memsrv.models.memory import MemoryInDB, MemoryUpdatePayload
+from memsrv.models.response import QueryResponse
 
 class VectorDBAdapter(ABC):
     """Abstract interface for any vector DB provider."""
@@ -26,7 +27,7 @@ class VectorDBAdapter(ABC):
     async def create_collection(self,
                                 collection_name: str,
                                 metadata: Optional[Dict[str, Any]] = None,
-                                config: Optional[Dict[str, Any]] = None):
+                                config: Optional[Dict[str, Any]] = None) -> bool:
         """Create a new collection (or get it if exists)."""
         pass
 
@@ -38,7 +39,7 @@ class VectorDBAdapter(ABC):
 
     @abstractmethod
     async def update(self,
-                     items: List[MemoryUpdatePayload]):
+                     items: List[MemoryUpdatePayload]) -> List[str]:
         """Updates items at given with new data, fact_id should be provided"""
         pass
 
@@ -50,14 +51,14 @@ class VectorDBAdapter(ABC):
 
     @abstractmethod
     async def get_by_ids(self,
-                         ids: List[str]):
+                         ids: List[str]) -> QueryResponse:
         """Get memory items by ids"""
         pass
 
     @abstractmethod
     async def query_by_filter(self,
                               filters: Dict[str, Any],
-                              limit: int = 5):
+                              limit: int = 5) -> QueryResponse:
         """Query items by filters"""
         pass
 
@@ -66,6 +67,6 @@ class VectorDBAdapter(ABC):
                                   query_embeddings: List[List[float]],
                                   query_texts: List[Optional[str]] = None,
                                   filters: Optional[Dict[str, Any]] = None,
-                                  top_k: int = 20):
+                                  top_k: int = 20) -> QueryResponse:
         """Query items by text with optional filters."""
         pass

--- a/src/memsrv/embeddings/providers/gemini.py
+++ b/src/memsrv/embeddings/providers/gemini.py
@@ -18,7 +18,7 @@ class GeminiEmbedding(BaseEmbedding):
         try:
             embedding_result = []
             result = await self.client.aio.models.embed_content(
-                model=self.embedding_model_name,
+                model=self.model_name,
                 contents=texts,
                 config=EmbedContentConfig(
                     task_type="RETRIEVAL_DOCUMENT",

--- a/src/memsrv/models/response.py
+++ b/src/memsrv/models/response.py
@@ -1,8 +1,15 @@
 """API response data models"""
-from typing import Optional, List, Literal
+from typing import Optional, Any, List, Dict, Literal
 from pydantic import BaseModel
 
 from memsrv.models.memory import MemoryMetadata
+
+class QueryResponse(BaseModel):
+    """Standard response model for database query operations."""
+    ids: List[List[str]]
+    documents: List[List[Optional[str]]]
+    metadatas: List[List[Dict[str, Any]]]
+    distances: Optional[List[List[float]]] = None
 
 class MemoryResponse(BaseModel):
     """Model for a single memory returned to the client."""


### PR DESCRIPTION
Resolves #5 
As mentioned in the issue, the returns are made modular by sticking to a datamodel `QueryResponse` for `get_by_ids`, `query_by_filter` and `query_by_similarity` methods.
- Modified all upstream code to stick to and use this returned values.