### PR TITLE
chore: Add Chroma async http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ memory_db/
 *.db
 *.sqlite
 chroma_db
+chroma/
 
 # scratch files
 scratchpad

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# memsrv
+# Memsrv
 
-A simple, self-hosted memory service boilerplate for LLMs and agent frameworks.
+**Memsrv** is a lightweight, self-hosted memory service for LLMs and agent frameworks. It helps your Agentic or LLM applications **remember facts across sessions**, retrieve information with **semantic search**, and plug into your existing agents with minimal setup. Think of it as a **memory layer** that makes your models more context-aware, consistent and personalized over time.
 
 ## Overview
 
-`memsrv` provides a streamlined solution for managing long term memory for your LLM and agentic applications. It allows you to extract, store, and retrieve factual information from conversations, leveraging vector embeddings for semantic search. The service is designed to be modular and extensible, supporting multiple vector database backends and LLM, Embedding providers.
+`Memsrv` is built to give LLMs and agent frameworks a reliable way to manage long-term memory. Instead of relying on session context alone, it provides a structured service for:
+* **Fact Extraction** - distilling key information from conversations into structured "memories".
+* **Vector based Storage** - encoding facts as embeddings for semantic search.
+* **Metadata Filtering** - retrieving memories tied to a specific user, session, or application.
 
-Key features:
+The service is:
+* **Modular** - supports multiple vector database backends (e.g., ChromaDB, Postgres with pgvector).
+* **Extensible** - works with different LLM and embedding providers.
+* **Integrable** - exposes a REST API so memories can be queried or updated from any application, or wrapped directly as tools within your agents.
 
-*   **Fact Extraction:** Automatically extracts key facts from conversation histories.
-*   **Semantic Search:** Uses vector embeddings to enable semantic retrieval of memories based on similarity to a query.
-*   **Metadata Filtering:** Supports filtering memories based on metadata such as user ID, session ID, and application ID.
-*   **Multiple Database Support:** Pluggable architecture supports different vector databases, such as ChromaDB and Postgres with pgvector.
-*   **REST API:** Exposes core memory services through a REST API for easy integration with other applications.
-    - The services can be wrapped around functions and can be used as tools with your agent(`memory_as_a_tool`).
-*   **CRUD Operations:** Supports Create, Read, Update, and Delete operations over the vector database for memory management.
+This design is inspired by [VertexAI Memory Bank](https://cloud.google.com/vertex-ai/generative-ai/docs/agent-engine/memory-bank/overview), but implemented in a lightweight, self-hosted way for developers who want full control over their agent’s memory layer.
 
 > Note: This project is still in active development. For status, milestones and next steps of this project refer [Project Milestones](./Milestones.md).
 
@@ -170,12 +170,12 @@ custom_memory_middleware = DynamicSystemPromptMiddleware(preload_memory_prompt_f
 root_agent = create_agent(
     ...
     middleware=[custom_memory_middleware],
-    context_schema=AgentContext,
+    context_schema=CustomAgentState,
     ...
 )
 ```
-You can playaround with both methods and see what works best.
->**A Note on Stability**: LangChain and LangGraph are under rapid development. The Agent Middleware API is a newer feature and may change in future versions, which could break the implementation of Method 2. Method 1 (Callable Prompt) relies on a more core, stable feature.
+You can play around with both methods and see what works best.
+>**A Note on Stability**: LangChain and LangGraph are always evolving. The Agent Middleware API is a newer feature and may change in future versions, which could break the implementation of Method 2. Method 1 (Callable Prompt) relies on a more core, stable feature.
 
 ## Directory Structure
 
@@ -183,7 +183,7 @@ You can playaround with both methods and see what works best.
 └── memsrv/
     ├── README.md                       # This file
     └── src/
-        ├── config.py                   # Configuration file for selecting LLMs and vector DBs
+        ├── config.py                   # Configuration file for selecting LLMs and vector DBs and respective config vars
         ├── server.py                   # Entry point for running the FastAPI server
         └── memsrv/
             ├── api/
@@ -196,11 +196,14 @@ You can playaround with both methods and see what works best.
             │   └── prompts.py          # Prompts used for fact extraction
             ├── db/
             │   ├── base_adapter.py     # Abstract base class for database adapters
+            │   ├── utils.py            # Utils file for common funcs for db
             │   └── adapters/
             │       ├── __init__.py
-            │       ├── chroma.py       # ChromaDB adapter
+            │       ├── chroma_lite.py  # ChromaDBLite adapter (local)
+            │       ├── chroma.py       # ChromaDB adapter (client-server)
             │       └── postgres.py     # Postgres adapter
             ├── embeddings/
+            │   ├── base_config.py      # Base class for embedding configurations
             │   ├── base_embedder.py    # Abstract base class for embedding providers
             │   └── providers/
             │       └── gemini.py       # Gemini embedding provider

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,5 @@
 """config file which selects llms, vector DBs"""
-from typing import Optional
+from typing import Optional, Dict, Any
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class MemoryConfig(BaseSettings):
@@ -20,16 +20,27 @@ class MemoryConfig(BaseSettings):
     # DB setup
     DB_PROVIDER: str = "chroma"
     DB_COLLECTION_NAME: str = "memories"
+    DB_DESCRIPTION: Optional[str] = "Default memory collection"
 
-    # Chroma
+    # Chroma lite(local)
     DB_PERSIST_DIR: Optional[str] = ""
 
-    # Postgres
+    # Postgres (for relational dbs)
     DATABASE_USER: Optional[str]
     DATABASE_PASSWORD: Optional[str]
     DATABASE_NAME: Optional[str]
     DATABASE_HOST: Optional[str] = "127.0.0.1"
     DATABASE_PORT: Optional[str] = "5432"
+
+    # Generic network DBs (Milvus, Chroma HTTP, etc.)
+    DB_HOST: Optional[str] = None
+    DB_PORT: Optional[int] = None
+    DB_USER: Optional[str] = None
+    DB_PASSWORD: Optional[str] = None
+
+    # Provider-specific configs (e.g. HNSW config, IVF params, connection pool size)
+    # should be added in valid dict format, they are directly unpacked
+    DB_PROVIDER_CONFIG: Dict[str, Any] = {}
 
     @property
     def llm_api_key(self) -> str:
@@ -40,7 +51,7 @@ class MemoryConfig(BaseSettings):
 
     @property
     def connection_string(self) -> Optional[str]:
-        """Constructs the connection string for postgres"""
+        """Constructs the connection string for postgres/relational DB"""
         if self.DB_PROVIDER == "postgres":
             return (
                 f"postgresql+asyncpg://{self.DATABASE_USER}:{self.DATABASE_PASSWORD}"
@@ -50,11 +61,18 @@ class MemoryConfig(BaseSettings):
 
     @property
     def db_config(self) -> dict:
-        """Prepares the config for db"""      
+        """Prepares the config for db adapters"""      
         return {
+            "collection_name": self.DB_COLLECTION_NAME,
+            "description": self.DB_DESCRIPTION,
+            "embedding_dim": self.EMBEDDING_DIM,
             "connection_string": self.connection_string,
             "persist_dir": self.DB_PERSIST_DIR,
-            "collection_name": self.DB_COLLECTION_NAME
+            "provider_config": self.DB_PROVIDER_CONFIG,
+            "host": self.DB_HOST,
+            "port": self.DB_PORT,
+            "user": self.DB_USER,
+            "password": self.DB_PASSWORD
         }
 
 memory_config = MemoryConfig()

--- a/src/config.py
+++ b/src/config.py
@@ -2,7 +2,7 @@
 from typing import Optional, Dict, Any, Literal
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-ALLOWED_DB_PROVIDERS = Literal["chroma_lite", "chroma", "postgres"]
+AllowedVectorDbProviders = Literal["chroma_lite", "chroma", "postgres"]
 
 class MemoryConfig(BaseSettings):
     """Simple config class for all services used"""
@@ -20,7 +20,7 @@ class MemoryConfig(BaseSettings):
     EMBEDDING_DIM: int = 768
 
     # DB setup
-    DB_PROVIDER: ALLOWED_DB_PROVIDERS = "chroma_lite"
+    DB_PROVIDER: AllowedVectorDbProviders = "chroma_lite"
     DB_COLLECTION_NAME: str = "memories"
     DB_DESCRIPTION: Optional[str] = "Default memory collection"
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,8 @@
 """config file which selects llms, vector DBs"""
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Literal
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+ALLOWED_DB_PROVIDERS = Literal["chroma_lite", "chroma", "postgres"]
 
 class MemoryConfig(BaseSettings):
     """Simple config class for all services used"""
@@ -18,12 +20,12 @@ class MemoryConfig(BaseSettings):
     EMBEDDING_DIM: int = 768
 
     # DB setup
-    DB_PROVIDER: str = "chroma"
+    DB_PROVIDER: ALLOWED_DB_PROVIDERS = "chroma_lite"
     DB_COLLECTION_NAME: str = "memories"
     DB_DESCRIPTION: Optional[str] = "Default memory collection"
 
     # Chroma lite(local)
-    DB_PERSIST_DIR: Optional[str] = ""
+    DB_PERSIST_DIR: Optional[str] = "./chroma_db"
 
     # Postgres (for relational dbs)
     DATABASE_USER: Optional[str]
@@ -38,7 +40,7 @@ class MemoryConfig(BaseSettings):
     DB_USER: Optional[str] = None
     DB_PASSWORD: Optional[str] = None
 
-    # Provider-specific configs (e.g. HNSW config, IVF params, connection pool size)
+    # Provider specific configs (e.g. HNSW config, IVF params, connection pool size)
     # should be added in valid dict format, they are directly unpacked
     DB_PROVIDER_CONFIG: Dict[str, Any] = {}
 

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,7 @@ class MemoryConfig(BaseSettings):
     # Embedding setup
     EMBEDDING_PROVIDER: str = "google"
     EMBEDDING_MODEL: str = "gemini-embedding-001"
+    EMBEDDING_DIM: int = 768
 
     # DB setup
     DB_PROVIDER: str = "chroma"

--- a/src/env.example
+++ b/src/env.example
@@ -8,6 +8,7 @@ GOOGLE_API_KEY=
 # [Embedding Config]
 EMBEDDING_PROVIDER=gemini
 EMBEDDING_MODEL=gemini-embedding-001
+EMBEDDING_DIM=768
 
 # [Vector DB Config]
 DB_PROVIDER=chroma

--- a/src/env.example
+++ b/src/env.example
@@ -13,9 +13,14 @@ EMBEDDING_DIM=768
 # [Vector DB Config]
 DB_PROVIDER=chroma
 DB_COLLECTION_NAME=memories
+# optional
+DB_DESCRIPTION="Default"
 
-# chroma specific (if DB_PROVIDER=chroma)
+# chroma lite (local chroma db)
 DB_PERSIST_DIR=./chroma_db
+# chroma http (chroma client-server)
+DB_HOST=
+DB_PORT=
 
 # postgres specific (if DB_PROVIDER=postgres)
 DATABASE_USER=user_name
@@ -23,3 +28,7 @@ DATABASE_PASSWORD=password_for_user
 DATABASE_NAME=db_name
 DATABASE_HOST=127.0.0.1
 DATABASE_PORT=5432
+
+# Provider specifc additional db config
+# chroma
+DB_PROVIDER_CONFIG={"hnsw": {"space": "cosine"}}

--- a/src/env.example
+++ b/src/env.example
@@ -11,7 +11,7 @@ EMBEDDING_MODEL=gemini-embedding-001
 EMBEDDING_DIM=768
 
 # [Vector DB Config]
-DB_PROVIDER=chroma
+DB_PROVIDER=chroma_lite
 DB_COLLECTION_NAME=memories
 # optional
 DB_DESCRIPTION="Default"

--- a/src/memsrv/core/memory_service.py
+++ b/src/memsrv/core/memory_service.py
@@ -1,4 +1,4 @@
-"""To add MemoryService class to add facts and to db services"""
+"""Core MemoryService class to manage memories"""
 # pylint: disable=too-many-locals, too-many-branches
 from typing import List, Dict, Optional, Any, Union
 
@@ -340,7 +340,7 @@ class MemoryService:
                                       filters: Dict[str, Any] = None,
                                       limit: int = 20):
         """Queries vector db and get memories similar to query and applies filters"""
-        # Note: Since this accepts bulk operation, it should result in
+        # FIXME: Since this accepts bulk operation, it should result in
         # [results1, results2...] but we just add everything to a single list for now
         if isinstance(query_texts, str):
             query_texts = [query_texts]

--- a/src/memsrv/core/memory_service.py
+++ b/src/memsrv/core/memory_service.py
@@ -166,7 +166,7 @@ class MemoryService:
             response_actions.extend(await self.update_memories(memories_to_update))
 
         if memories_to_delete:
-            response_actions.extend(self.delete_memories(memories_to_delete))
+            response_actions.extend(await self.delete_memories(memories_to_delete))
 
         logger.info(response_actions)
 

--- a/src/memsrv/db/adapters/chroma.py
+++ b/src/memsrv/db/adapters/chroma.py
@@ -1,4 +1,4 @@
-"""Chroma db implementation"""
+"""Chroma db implementation using client-server chroma setup"""
 # pylint: disable=too-many-positional-arguments, signature-differs
 from typing import Dict, Any
 import chromadb
@@ -10,7 +10,7 @@ from memsrv.models.response import QueryResponse
 logger = get_logger(__name__)
 
 class ChromaDBAdapter(VectorDBAdapter):
-    """Implements vector db ops for chroma DB"""
+    """Implements vector db ops for chroma DB via http client-server"""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._client_kwargs = {"host": self.host, "port": self.port}

--- a/src/memsrv/db/adapters/chroma_lite.py
+++ b/src/memsrv/db/adapters/chroma_lite.py
@@ -1,4 +1,4 @@
-"""Chroma db implementation"""
+"""Chroma db implementation using local/persistent db setup"""
 # pylint: disable=too-many-positional-arguments, signature-differs
 from typing import Dict, Any
 import chromadb
@@ -10,7 +10,7 @@ from memsrv.models.response import QueryResponse
 logger = get_logger(__name__)
 
 class ChromaLiteDBAdapter(VectorDBAdapter):
-    """Implements vector db ops for chroma DB"""
+    """Implements vector db ops for chroma DB using persistent dir"""
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.client = chromadb.PersistentClient(path=self.persist_dir)

--- a/src/memsrv/db/base_adapter.py
+++ b/src/memsrv/db/base_adapter.py
@@ -10,16 +10,28 @@ class VectorDBAdapter(ABC):
 
     def __init__(self,
                  collection_name: str,
+                 description: str,
+                 embedding_dim: str,
                  connection_string: Optional[str] = None,
-                 persist_dir: Optional[str] = None):
+                 persist_dir: Optional[str] = None,
+                 provider_config: Optional[Dict[str, Any]] = None,
+                 host: Optional[str] = None,
+                 port: Optional[int] = None,
+                 user: Optional[str] = None,
+                 password: Optional[str] = None):
+        self.collection_name = collection_name
+        self.embedding_dim = embedding_dim
+        self.description = description
         self.connection_string = connection_string
         self.persist_dir = persist_dir
-        self.collection_name = collection_name
+        self.provider_config = provider_config or {}
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
 
     @abstractmethod
-    async def setup_database(self,
-                             metadata: Optional[Dict[str, Any]] = None,
-                             config: Optional[Dict[str, Any]] = None):
+    async def setup_database(self):
         """Class method to setup database during startup"""
         pass
 

--- a/src/memsrv/embeddings/base_config.py
+++ b/src/memsrv/embeddings/base_config.py
@@ -1,0 +1,11 @@
+"""Base class for embedding config parameters"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class BaseEmbeddingConfig:
+    """Base config for embedding parameters"""
+    model_name: str
+    api_key: str
+    embedding_dims: Optional[int] = 768

--- a/src/memsrv/embeddings/base_embedder.py
+++ b/src/memsrv/embeddings/base_embedder.py
@@ -1,15 +1,20 @@
 """Base class for embeddings"""
 # pylint: disable=unnecessary-pass
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Dict, List, Optional, Union
+
+from memsrv.embeddings.base_config import BaseEmbeddingConfig
 
 class BaseEmbedding(ABC):
     """Abstract interface for any embedding model provider."""
     def __init__(self,
-                 model_name: str,
-                 api_key: str):
-        self.model_name = model_name
-        self.api_key = api_key
+                 config: Optional[Union[BaseEmbeddingConfig, Dict]]=None):
+        if isinstance(config, dict):
+            self.config = BaseEmbeddingConfig(**config)
+        elif isinstance(config, BaseEmbeddingConfig):
+            self.config = config
+        else:
+            raise ValueError("Missing config when intializing embedding service")
 
     @abstractmethod
     async def generate_embeddings(self, texts: List[str]) -> List[List[float]]:

--- a/src/memsrv/embeddings/providers/gemini.py
+++ b/src/memsrv/embeddings/providers/gemini.py
@@ -1,28 +1,29 @@
 """Embeddings generator using google embeds"""
-from typing import List
+from typing import List, Optional
 from google.genai.client import Client as geminiClient
 from google.genai.types import EmbedContentConfig
 from memsrv.utils.logger import get_logger
 from memsrv.embeddings.base_embedder import BaseEmbedding
+from memsrv.embeddings.base_config import BaseEmbeddingConfig
 
 logger = get_logger(__name__)
 
 class GeminiEmbedding(BaseEmbedding):
     """Embedding module for generating embeddings using gemini api"""
-    def __init__(self, model_name: str = "gemini-embedding-001", api_key: str = None):
-        super().__init__(model_name, api_key)
-        self.client = geminiClient(api_key=api_key)
+    def __init__(self, config: Optional[BaseEmbeddingConfig]=None):
+        super().__init__(config=config)
+        self.client = geminiClient(api_key=self.config.api_key)
 
     async def generate_embeddings(self, texts: List[str]) -> List[List[float]]:
         """Generates embeddings for a list of texts using Gemini embedding models."""
         try:
             embedding_result = []
             result = await self.client.aio.models.embed_content(
-                model=self.model_name,
+                model=self.config.model_name,
                 contents=texts,
                 config=EmbedContentConfig(
                     task_type="RETRIEVAL_DOCUMENT",
-                    output_dimensionality=768
+                    output_dimensionality=self.config.embedding_dims
                 )
             )
             for embedding in result.embeddings:

--- a/src/memsrv/utils/factory.py
+++ b/src/memsrv/utils/factory.py
@@ -57,7 +57,7 @@ class EmbeddingFactory:
 
         if provider not in cls.provider_mapping:
             raise ValueError(f"Unsupported Embedding provider: {provider}.")
-        
+
         # FIXME: Using llm key for now but should seperate later
         embedder_class = load_class(cls.provider_mapping[provider])
         config = BaseEmbeddingConfig(model_name=model_name,

--- a/src/memsrv/utils/factory.py
+++ b/src/memsrv/utils/factory.py
@@ -70,8 +70,9 @@ class DBFactory:
     """Factory for creating database adapter instances"""
 
     provider_mapping = {
+        "chroma_lite": "memsrv.db.adapters.chroma_lite.ChromaLiteDBAdapter",
         "chroma": "memsrv.db.adapters.chroma.ChromaDBAdapter",
-        "postgres": "memsrv.db.adapters.postgres.PostgresDBAdapter",
+        "postgres": "memsrv.db.adapters.postgres.PostgresDBAdapter"
     }
 
     @classmethod

--- a/src/memsrv/utils/factory.py
+++ b/src/memsrv/utils/factory.py
@@ -7,6 +7,7 @@ from typing import Any, Type
 from config import memory_config
 from memsrv.llms.base_config import BaseLLMConfig
 from memsrv.llms.base_llm import BaseLLM
+from memsrv.embeddings.base_config import BaseEmbeddingConfig
 from memsrv.embeddings.base_embedder import BaseEmbedding
 from memsrv.db.base_adapter import VectorDBAdapter
 from memsrv.core.memory_service import MemoryService
@@ -52,13 +53,18 @@ class EmbeddingFactory:
         """Creates the embedding instance using the config"""
         provider = memory_config.EMBEDDING_PROVIDER
         model_name = memory_config.EMBEDDING_MODEL
+        embedding_dim = memory_config.EMBEDDING_DIM
 
         if provider not in cls.provider_mapping:
             raise ValueError(f"Unsupported Embedding provider: {provider}.")
-
-        embedder_class = load_class(cls.provider_mapping[provider])
+        
         # FIXME: Using llm key for now but should seperate later
-        return embedder_class(model_name=model_name, api_key=memory_config.llm_api_key)
+        embedder_class = load_class(cls.provider_mapping[provider])
+        config = BaseEmbeddingConfig(model_name=model_name,
+                                     api_key=memory_config.llm_api_key,
+                                     embedding_dims=embedding_dim)
+
+        return embedder_class(config)
 
 class DBFactory:
     """Factory for creating database adapter instances"""


### PR DESCRIPTION
Resolves #24 
Changelog:
1. Seperated chroma persist dir from chroma http client. Now the database layer can be hosted in another engine and can be communicated with memory service asynchronously.
2. Made two files `chroma.py` containg AsynHttpClient() and `chroma_lite`, which uses Persistent Directory in local, which vanishes once the instance starts again, it can't be accessed between different instances.
3. Updated config to read additional params like embedding dims etc and made it more modular.
4. Updated main readme, the intro and overview section.